### PR TITLE
fix set-up issue with bash login shell

### DIFF
--- a/common/scripts/api_env
+++ b/common/scripts/api_env
@@ -2,14 +2,13 @@
 # the code in this repo.
 
 # figure out the location of this script, which is a shell-dependent process
-case "$(basename $0)" in
-  bash)
+if [ "$0" = '-bash' ] || [ "$0" = '/bin/bash' ] ; then
     SCRIPT_NAME="${BASH_SOURCE[0]}"
-    ;;
-  *)
+else
     SCRIPT_NAME="$0"
-    ;;
-esac
+fi
+
+echo $SCRIPT_NAME
 
 # get the location of this script
 SCRIPT_DIR=$(cd $(dirname ${SCRIPT_NAME}); pwd)


### PR DESCRIPTION
Something in the IT configuration of developer laptops at Pinterest changed in the last couple of hours that broken the environment set-up script. It has something to do with starting bash as a login shell. This change fixes the related problem in the api environment script.
