### PR TITLE
python: stop unintentional redirects to endpoints

### DIFF
--- a/python/scripts/get_pin.py
+++ b/python/scripts/get_pin.py
@@ -20,7 +20,7 @@ def main(argv=[]):
 
     # get configuration from defaults and/or the environment
     api_config = ApiConfig()
-    api_config.verbosity = 3
+    api_config.verbosity = 2
 
     # imports that depend on the version of the API
     from pin import Pin

--- a/python/src/v3/api_object.py
+++ b/python/src/v3/api_object.py
@@ -76,7 +76,7 @@ class ApiObject:
     def get_response(self, path):
         if self.api_config.verbosity >= 2:
             print(f'GET {self.api_uri + path}')
-        return requests.get(self.api_uri + path, headers=self.access_token.header())
+        return requests.get(self.api_uri + path, headers=self.access_token.header(), allow_redirects=False)
 
     def request_data(self, path):
         return self.unpack(self.get_response(path)).get('data')
@@ -86,13 +86,13 @@ class ApiObject:
             print(f'PUT {self.api_uri + path}')
         if self.api_config.verbosity >= 3:
             print(put_data)
-        response = requests.put(self.api_uri + path, data = put_data, headers=self.access_token.header())
+        response = requests.put(self.api_uri + path, data = put_data, headers=self.access_token.header(), allow_redirects=False)
         return self.unpack(response).get('data')
 
     def post_data(self, path):
         if self.api_config.verbosity >= 2:
             print(f'POST {self.api_uri + path}')
-        response = requests.post(self.api_uri + path, headers=self.access_token.header())
+        response = requests.post(self.api_uri + path, headers=self.access_token.header(), allow_redirects=False)
         return self.unpack(response).get('data')
 
     def get_iterator(self, path):

--- a/python/src/v3/board.py
+++ b/python/src/v3/board.py
@@ -8,7 +8,7 @@ class Board(ApiObject):
     def get(self):
         if not self.board_id:
             raise ValueError('board_id must be set to get a board')
-        return self.request_data(f'/v3/boards/{self.board_id}')
+        return self.request_data(f'/v3/boards/{self.board_id}/')
 
     @classmethod
     def print_summary(klass, board_data):

--- a/python/src/v3/pin.py
+++ b/python/src/v3/pin.py
@@ -8,7 +8,7 @@ class Pin(ApiObject):
     def get(self):
         if not self.pin_id:
             raise ValueError('pin_id must be set to get a pin')
-        return self.request_data('/v3/pins/{}'.format(self.pin_id))
+        return self.request_data('/v3/pins/{}/'.format(self.pin_id))
 
     @classmethod
     def print_summary(klass, pin_data):

--- a/python/tests/scripts/test_analytics_api_example.py
+++ b/python/tests/scripts/test_analytics_api_example.py
@@ -11,7 +11,7 @@ class AnalyticsApiExampleTest(IntegrationMocks):
     report_url_filename = 'here_is_the_filename.txt' # filename in the report url
     download_filename = 'test_report_file.txt' # filename "entered" for download
 
-    def mock_requests_post(self, uri, headers=None, data=None):
+    def mock_requests_post(self, uri, headers=None, data=None, allow_redirects=True):
         # request from AsyncReport.request_report
         print('mock_requests_post', uri, headers, data)
         self.requests_post_calls += 1
@@ -20,7 +20,7 @@ class AnalyticsApiExampleTest(IntegrationMocks):
         response.json.return_value = {'data': {'token': 'test-report-token'}}
         return response
 
-    def mock_requests_get(self, uri, headers=None, data=None, stream=False):
+    def mock_requests_get(self, uri, headers=None, data=None, stream=False, allow_redirects=True):
         print('mock_requests_get', uri, headers, data)
         self.requests_get_calls += 1
         report_url = f'test-report-url/x-y-z/{self.report_url_filename}?long-identifier-string'

--- a/python/tests/scripts/test_get_access_token.py
+++ b/python/tests/scripts/test_get_access_token.py
@@ -3,7 +3,7 @@ import mock
 from integration_mocks import IntegrationMocks
 
 class GetAccessTokenTest(IntegrationMocks):
-    def mock_requests_put(self, uri, headers=None, data=None):
+    def mock_requests_put(self, uri, headers=None, data=None, allow_redirects=True):
         print('mock_requests_put', uri, headers, data)
         self.put_uri = uri
         self.requests_put_calls += 1
@@ -16,7 +16,7 @@ class GetAccessTokenTest(IntegrationMocks):
                                       }
         return response
 
-    def mock_requests_get(self, uri, headers=None, data=None):
+    def mock_requests_get(self, uri, headers=None, data=None, allow_redirects=True):
         print('mock_requests_get', uri, headers, data)
         self.get_uri = uri
         self.requests_get_calls += 1

--- a/python/tests/scripts/test_get_businesses.py
+++ b/python/tests/scripts/test_get_businesses.py
@@ -3,8 +3,8 @@ import mock
 from integration_mocks import IntegrationMocks
 
 class GetBusinessesTest(IntegrationMocks):
-    def mock_requests_put(self, uri, headers=None, data=None):
-        print('mock_requests_put', uri, headers, data)
+    def mock_requests_put(self, uri, headers=None, data=None, allow_redirects=True):
+        print('mock_requests_put', uri, headers, data, allow_redirects)
         self.requests_put_calls += 1
         response = mock.MagicMock()
         response.__str__.return_value = '<Response [200]>'
@@ -16,8 +16,8 @@ class GetBusinessesTest(IntegrationMocks):
                                       }
         return response
 
-    def mock_requests_get(self, uri, headers=None, data=None):
-        print('mock_requests_get', uri, headers, data)
+    def mock_requests_get(self, uri, headers=None, data=None, allow_redirects=True):
+        print('mock_requests_get', uri, headers, data, allow_redirects)
         response = mock.MagicMock()
         response.__str__.return_value = '<Response [200]>'
         if (uri == 'https://api.pinterest.com/v3/users/me/'):

--- a/python/tests/scripts/test_refresh_example.py
+++ b/python/tests/scripts/test_refresh_example.py
@@ -4,7 +4,7 @@ from integration_mocks import IntegrationMocks
 
 class RefreshExampleTest(IntegrationMocks):
     def mock_requests_put(self, uri, headers=None, data=None):
-        print('mock_requests_put', uri, headers, data)
+        print('mock_requests_put', uri, headers, data, allow_redirects=True)
         self.requests_put_calls += 1
         response = mock.MagicMock()
         response.__str__.return_value = '<Response [200]>'
@@ -16,7 +16,7 @@ class RefreshExampleTest(IntegrationMocks):
                                       }
         return response
 
-    def mock_requests_get(self, uri, headers=None, data=None):
+    def mock_requests_get(self, uri, headers=None, data=None, allow_redirects=True):
         print('mock_requests_get', uri, headers, data)
         response = mock.MagicMock()
         response.__str__.return_value = '<Response [200]>'

--- a/python/tests/src/v3/test_api_object.py
+++ b/python/tests/src/v3/test_api_object.py
@@ -28,7 +28,7 @@ class ApiObjectTest(unittest.TestCase):
         api_object = ApiObject(api_config, access_token)
         response = api_object.request_data('/test_path')
         self.assertEqual(response, 'test_response_data')
-        mock_requests_get.assert_called_once_with('test_uri/test_path', headers='test_headers')
+        mock_requests_get.assert_called_once_with('test_uri/test_path', headers='test_headers', allow_redirects=False)
 
         mock_response.ok = False
         mock_response.status_code = 429

--- a/python/tests/src/v3/test_board.py
+++ b/python/tests/src/v3/test_board.py
@@ -11,7 +11,7 @@ class BoardTest(unittest.TestCase):
 
         mock_api_object_request_data.return_value = 'test_response'
         response = test_board.get()
-        mock_api_object_request_data.assert_called_once_with('/v3/boards/test_board_id')
+        mock_api_object_request_data.assert_called_once_with('/v3/boards/test_board_id/')
         self.assertEqual(response, 'test_response')
 
     @mock.patch('src.v3.board.ApiObject.put_data')

--- a/python/tests/src/v3/test_pin.py
+++ b/python/tests/src/v3/test_pin.py
@@ -11,7 +11,7 @@ class PinTest(unittest.TestCase):
 
         mock_api_object_request_data.return_value = 'test_response'
         response = test_pin.get()
-        mock_api_object_request_data.assert_called_once_with('/v3/pins/test_pin_id')
+        mock_api_object_request_data.assert_called_once_with('/v3/pins/test_pin_id/')
         self.assertEqual(response, 'test_response')
 
     @mock.patch('src.v3.pin.ApiObject.put_data')


### PR DESCRIPTION
Missing slashes at the end of the GET pin and board endpoints were causing redirects. This change disables the redirects to ensure that the endpoints are specified correctly.
