### PR TITLE
python: minor improvements

### DIFF
--- a/python/scripts/copy_board.py
+++ b/python/scripts/copy_board.py
@@ -166,6 +166,9 @@ def main(argv=[]):
 
         # copy board pins
         for pin_data in source_board.get_pins():
+            # ignore pins in sections for now. they will be copied into each section
+            if pin_data.get('board_section_id'):
+                continue
             if args.dry_run:
                 print('dry-run: skipping attempt to create board pin:')
                 Pin.print_summary(pin_data)

--- a/python/scripts/get_access_token.py
+++ b/python/scripts/get_access_token.py
@@ -10,6 +10,9 @@ from access_token import AccessToken
 
 def main(argv=[]):
     """
+    This script retrieves an OAuth 2.0 access token. See the "OAuth Authentication"
+    section of the top-level README in this repository for more information.
+
     The arguments for this script are intended to be used as follows:
      -w / --write :
        Save the access token to a file in JSON format so that it can be used with other scripts.
@@ -29,7 +32,9 @@ def main(argv=[]):
        To provide a quick start for new developers, this script requests an access token with the default
        set of scopes for the application provided in the environment (with the PINTEREST_APP_ID and
        PINTEREST_APP_SECRET variables). This argument, which requires a comma-separated list of valid
-       OAuth scopes, allows experimentation with different sets of scopes.
+       OAuth scopes, allows experimentation with different sets of scopes. Specifying scopes prevents
+       the access token from being read from the environment or file system, and forces the use of
+       the browser-based OAuth process.
     """
     parser = argparse.ArgumentParser(description='Get Pinterest OAuth token')
     parser.add_argument('-w', '--write', action='store_true', help='write access token to file')
@@ -52,7 +57,9 @@ def main(argv=[]):
     if args.scopes:
         # use the comma-separated list of scopes passed as a command-line argument
         scopes = list(map(lambda arg: Scope[arg.upper()], args.scopes.split(',')))
-    access_token.fetch(scopes=scopes)
+        access_token.oauth(scopes=scopes)
+    else:
+        access_token.fetch()
 
     # Note: It is best practice not to print credentials in clear text.
     # Pinterest engineers asked for this capability to make it easier to support partners.

--- a/python/scripts/get_board.py
+++ b/python/scripts/get_board.py
@@ -45,7 +45,9 @@ def main(argv=[]):
 
     if args.pins:
         for pin_data in board.get_pins():
-            Pin.print_summary(pin_data)
+            # ignore pins in sections for now. they will be printed for each section
+            if not pin_data.get('board_section_id'):
+                Pin.print_summary(pin_data)
 
     for section_data in board.get_sections():
         board.print_section(section_data)

--- a/python/scripts/get_user_boards.py
+++ b/python/scripts/get_user_boards.py
@@ -26,7 +26,6 @@ def main(argv=[]):
     # include_empty is an example of an API parameter
     parser.add_argument('--include-empty', help='Include empty boards?', dest='include_empty', action='store_true')
     parser.add_argument('--no-include-empty', dest='include_empty', action='store_false')
-    parser.set_defaults(include_empty=True)
     parser.add_argument('--include-archived', help='Include archived boards?', dest='include_archived', action='store_true')
     parser.add_argument('--no-include-archived', dest='include_archived', action='store_false')
     parser.set_defaults(include_archived=False)
@@ -51,10 +50,11 @@ def main(argv=[]):
     user_me_data = user_me.get()
 
     # get information about all of the boards in the user's profile
-    query_parameters={'page_size': args.page_size,
-                      'include_empty': args.include_empty,
-                      'include_archived': args.include_archived,
-                      }
+    query_parameters={'page_size': args.page_size}
+    if (args.include_empty):
+        query_parameters['include_empty'] = args.include_empty
+    if (args.include_archived):
+        query_parameters['include_archived'] = args.include_archived
     board_iterator = user_me.get_boards(user_me_data, query_parameters)
     user_me.print_multiple(args.page_size, 'board', Board, board_iterator)
 

--- a/python/src/access_token.py
+++ b/python/src/access_token.py
@@ -71,11 +71,15 @@ class AccessToken:
         put_data = {'code': auth_code,
                     'redirect_uri': self.api_config.redirect_uri,
                     'grant_type': 'authorization_code'}
+        if (self.api_config.verbosity >= 2):
+            print('PUT', self.api_config.api_uri + '/v3/oauth/access_token/')
         response = requests.put(self.api_config.api_uri + '/v3/oauth/access_token/',
                                 headers=self.auth_headers, data=put_data)
         print(response)
         respdict = response.json()
         print('status: ' + respdict['status'])
+        if (self.api_config.verbosity >= 3):
+            print('x-pinterest-rid:', response.headers.get('x-pinterest-rid'))
         """
         The scope returned in the response includes all of the scopes that
         have been approved now or in the past by the user.
@@ -83,6 +87,7 @@ class AccessToken:
         print('scope: ' + respdict['scope'])
         self.access_token = respdict['access_token']
         self.refresh_token = respdict['data'].get('refresh_token')
+        self.scopes = respdict['scope']
         if self.refresh_token:
             print('received refresh token')
 
@@ -104,6 +109,7 @@ class AccessToken:
             self.name = data.get('name') or 'access_token'
             self.access_token = data['access_token']
             self.refresh_token = data.get('refresh_token')
+            self.scopes = data.get('scopes')
         print(f'read {self.name} from {self.path}')
 
     def write(self):
@@ -117,7 +123,8 @@ class AccessToken:
             # write the information to the file
             json.dump({'name': self.name,
                        'access_token': self.access_token,
-                       'refresh_token': self.refresh_token},
+                       'refresh_token': self.refresh_token,
+                       'scopes': self.scopes},
                       jsonfile,
                       indent=2)
 
@@ -149,7 +156,11 @@ class AccessToken:
         print(f'refreshing {self.name}...')
         put_data = {'grant_type': 'refresh_token',
                     'refresh_token': self.refresh_token}
+        if (self.api_config.verbosity >= 2):
+            print('PUT', self.api_config.api_uri + '/v3/oauth/access_token/')
         response = requests.put(self.api_config.api_uri + '/v3/oauth/access_token/',
                                 headers=self.auth_headers, data=put_data)
         print(response)
+        if (self.api_config.verbosity >= 3):
+            print('x-pinterest-rid:', response.headers.get('x-pinterest-rid'))
         self.access_token = response.json()['access_token']

--- a/python/tests/src/test_access_token.py
+++ b/python/tests/src/test_access_token.py
@@ -18,6 +18,7 @@ class AccessTokenTest(unittest.TestCase):
         mock_api_config.redirect_uri = 'test-redirect-uri'
         mock_api_config.oauth_token_dir = 'test-token-dir'
         mock_api_config.version = 'v3'
+        mock_api_config.verbosity = 3
 
         mock_response = mock.MagicMock()
         mock_response.__str__.return_value = '<Response [200]>'
@@ -64,6 +65,7 @@ class AccessTokenTest(unittest.TestCase):
         mock_response = mock.MagicMock()
         mock_response.__str__.return_value = '<Response [200]>'
         mock_response.json.return_value = {'access_token': 'new-access-token'}
+        mock_response.headers = {'x-pinterest-rid': 'mock-request-id'}
         mock_requests_put.reset_mock()
         mock_requests_put.return_value = mock_response
 
@@ -127,7 +129,8 @@ class AccessTokenTest(unittest.TestCase):
 
         access_token_dict = {'name': 'access_token_from_file',
                              'access_token': 'test access token from json',
-                             'refresh_token': 'test refresh token from json'
+                             'refresh_token': 'test refresh token from json',
+                             'scopes': 'test-scope-1,test-scope-2'
                              }
 
         # Test access token JSON file read


### PR DESCRIPTION
In python code:
* force complete OAuth 2.0 exchange when scopes are specified (because it's confusing not to update the scopes when they are specified, and it's convenient to be able to force an exchange instead of reading from the environment or file system)
* save/restore scopes associated with an access token in the file system
* ignore pins in sections to prevent duplicate printing or create requests
* send board query parameters only when necessary
* print pinterest request identifier at high verbosity level to help with debugging oauth issues