### PR TITLE
use http instead of https for oauth redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *~
-*.pem
 common/scripts/api_app_credentials
 common/oauth_tokens

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository has code that is intended to provide a quick start for working w
 
 ## Quick Start
 
-1. Set up the environment with your credentials (app ID and secret, https://localhost certificates). This configuration works with the code in all of the language-specific directories.
+1. Set up the environment with your credentials (app ID and secret). This configuration works with the code in all of the language-specific directories.
 
    * Get an application ID and secret by hitting the "Start building" button at [https://developers.pinterest.com/](https://developers.pinterest.com/). Approval from a contact at Pinterest is required to see the application secret. (We're working on some updates to our program and are currently taking a pause in reviewing applications while we focus on what's next. If you'd still like to apply to our program we'll reach out to the email associated with your account once there's an update. We're excited to share with you what we've been working on.)
    * Put your app ID and secret in an environment script file.
@@ -20,33 +20,22 @@ This repository has code that is intended to provide a quick start for working w
      ```
    * Configure the redirect URI required by this code.
      1. Click on the name of your application at [https://developers.pinterest.com/manage/](https://developers.pinterest.com/manage/).
-     2. In the box labeled "Redirect URIs," enter `https://localhost:8085/`.
+     2. In the box labeled "Redirect URIs," enter `http://localhost:8085/`.
      3. Hit the return (enter) key.
      4. Hit the Save button next in the "You have unsaved changes" box that appears after hitting the return (enter) key.
-   * Create a certificate so that your browser will trust https://localhost/. This configuration will streamline the OAuth process on your development machine. We recommend installing and using [mkcert](https://github.com/FiloSottile/mkcert) for this purpose.
-     ```
-     $ mkdir -p common/certs # create the directory
-     $ cd common/certs
-     $ mkcert -install # if you have not already run this command
-     $ mkcert localhost
-     $ cd ../..
-     ```
    * Run the environment set-up script and verify the results.
      ```
      $ . ./common/scripts/api_env
      $ env | grep PINTEREST_APP
      PINTEREST_APP_ID=<number>
      PINTEREST_APP_SECRET=<string>
-     $ env | grep HTTPS
-     HTTPS_KEY_FILE=<this directory>/common/scripts/../certs/localhost-key.pem
-     HTTPS_CERT_FILE=<this directory>/common/scripts/../certs/localhost.pem
      ```
 
 2. Pick one of the language directories (currently bash, nodejs and python) and follow the directions in the README file in the directory.
 
 ## OAuth Authentication
 
-Access to Pinterest APIs via User Authorization requires following a flow based on [OAuth 2.0](https://tools.ietf.org/html/rfc6749). For details regarding OAuth, please reference our [developer docs](https://developers.pinterest.com/docs/redoc/#section/User-Authorization). The code in this repo demonstrates how to initiate the flow by starting a browser, and then handling the OAuth redirect to the development machine (localhost). The browser is used to obtain an authorization code, and then the code invoked by the redirect exchanges the authorization code for an access token. The Pinterest API requires using a secure method for the redirect (https), which is the reason why it's necessary to create the SSL/TLS certificate for localhost.
+Access to Pinterest APIs via User Authorization requires following a flow based on [OAuth 2.0](https://tools.ietf.org/html/rfc6749). For details regarding OAuth, please reference our [developer docs](https://developers.pinterest.com/docs/redoc/#section/User-Authorization). The code in this repo demonstrates how to initiate the flow by starting a browser, and then handling the OAuth redirect to the development machine (localhost). The browser is used to obtain an authorization code, and then the code invoked by the redirect exchanges the authorization code for an access token.
 
 An access token is used to authenticate most API calls. In general, access tokens are valid for relatively long periods of time, in order to avoid asking users to go through the OAuth flow too often. When an access token expires, it is possible to refresh the token -- a capability that the code in this repo also demonstrates.
 
@@ -61,12 +50,10 @@ The precedence order in this repo for obtaining an access token is: environment,
 
 ## Security Notes
 
-* Best development practice is to keep authentication credentials (like your app secret, certificate key, and access tokens) out of code.
+* Best development practice is to keep authentication credentials (like your app secret and OAuth access tokens) out of code.
 * When using a JSON-encoded file to specify an access token, use a secure file mode when possible. For example: `chmod 600 common/oauth_tokens/*`
 * When specifying credentials in environment variables, export it from a script file instead of on the shell command line. (Commands -- along with the clear text credentials -- are often stored in history and log files.)
-* The recommended locations for your credentials (`common/scripts/api_app_credentials`), certificates (`common/certs`), and access tokens (`common/oauth_tokens`) are listed in the `.gitignore` file to help avoid checking this material into a git repo.
-* To disable the mkcert root certificate, you can run `mkcert -uninstall` and then reenable it later with `mkcert -install`.
-* You're safe from abuse after running `mkcert -uninstall`, but to do a deeper cleaning you can run `rm -rf "$(mkcert -CAROOT)"` and also remove the certificate from your computer's trust store (e.g. using the Keychain Access app on MacOS).
+* The recommended locations for your credentials (`common/scripts/api_app_credentials`), and access tokens (`common/oauth_tokens`) are listed in the `.gitignore` file to help avoid checking this material into a git repo.
 
 ## Repository Layout
 

--- a/bash/README.md
+++ b/bash/README.md
@@ -1,0 +1,23 @@
+# Bash Quickstart
+
+Shell code that makes it as easy as possible to see how the Pinterest API works.
+
+## Quick Start
+
+1. Netcat (the `nc` command) is used to run a simple web server to receive the OAuth redirect and is available on many operating systems. Check to make sure that it is installed on your development system by running `nc -h`. MacOS has netcat by default. Use your operating system's package manager to install netcat if necessary.
+
+2. Follow the directions in the README at the top level of this repo for configuring your application ID and application secret.
+
+3. From the top of this repo, change your working directory to this directory: `cd bash`
+
+4. Set up the shell environment.
+
+   ```
+   $ . ../common/scripts/api_env
+   ```
+
+5. Run the sample script.
+
+   ```
+   $ ./scripts/get_access_token.sh
+   ```

--- a/bash/scripts/get_access_token.sh
+++ b/bash/scripts/get_access_token.sh
@@ -13,12 +13,10 @@
 
 # Get configuration from environment or defaults.
 : ${REDIRECT_PORT:=8085}
-: ${HTTPS_KEY_FILE:=localhost-key.pem}
-: ${HTTPS_CERT_FILE:=localhost.pem}
 : ${PINTEREST_API_URI:=https://api.pinterest.com}
 : ${PINTEREST_OAUTH_URI:=https://www.pinterest.com}
 : ${REDIRECT_LANDING_URI:=https://developers.pinterest.com/manage/${PINTEREST_APP_ID}}
-REDIRECT_URI="https://localhost:${REDIRECT_PORT}/"
+REDIRECT_URI="http://localhost:${REDIRECT_PORT}/"
 
 # Note that the application id and secrect have no defaults,
 # because it is best practice not to store credentials in code.
@@ -35,14 +33,13 @@ SCOPE=read_users
 # This call opens the browser with the oauth information in the URI.
 open "${PINTEREST_OAUTH_URI}/oauth/?consumer_id=${PINTEREST_APP_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&response_type=code" &
 
-# 1. Use openssl to run the web browser to handle the redirect from the oauth call.
+# 1. Use netcat (nc) to run the web browser to handle the redirect from the oauth call.
 # 2. Wait for the response.
 # 3. Redirect using a HTTP 301 response to the landing URI.
-REDIRECT_SESSION=$(openssl s_server -accept ${REDIRECT_PORT} -cert ${HTTPS_CERT_FILE} -key ${HTTPS_KEY_FILE} 2>&1 <<EOF
+REDIRECT_SESSION=$(nc -l localhost ${REDIRECT_PORT} 2>&1 <<EOF
 HTTP/1.1 301 Moved Permanently
 Location: ${REDIRECT_LANDING_URI}
 
-Q
 EOF
 )
 

--- a/common/certs/initialize.sh
+++ b/common/certs/initialize.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-mkcert localhost

--- a/common/scripts/api_env
+++ b/common/scripts/api_env
@@ -23,16 +23,6 @@ fi
 unset PINTEREST_API_URI
 unset PINTEREST_OAUTH_URI
 
-# location of https certificates specified in the documentation
-export HTTPS_KEY_FILE="${SCRIPT_DIR}/../certs/localhost-key.pem"
-export HTTPS_CERT_FILE="${SCRIPT_DIR}/../certs/localhost.pem"
-
-# Some programs need access to the location of the CA bundle.
-# For example, using this CA bundle is required for python integration tests.
-if (which mkcert >/dev/null) ; then
-   export HTTPS_CA_BUNDLE="$(mkcert -CAROOT)"/rootCA.pem
-fi
-
 # location to read and write OAuth tokens
 export PINTEREST_OAUTH_TOKEN_DIR="${SCRIPT_DIR}/../oauth_tokens/"
 mkdir -p "${PINTEREST_OAUTH_TOKEN_DIR}"

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -4,8 +4,7 @@ JavaScript code that makes it easy to get started with the Pinterest API.
 
 ## Quick Start
 
-1. Follow the directions at the top level of this repo for configuring
-your application ID, application secret, and https certificates.
+1. Follow the directions at the top level of this repo for configuring your application ID and application secret.
 
 2. From the top of this repo, change your working directory to this directory: `cd nodejs`
 

--- a/nodejs/src/api_config.js
+++ b/nodejs/src/api_config.js
@@ -6,13 +6,11 @@ export class ApiConfig {
     // of ports that could be used in case some other service is listening on
     // the hard-coded port.
     const DEFAULT_PORT = 8085;
-    const DEFAULT_REDIRECT_URI = 'https://localhost:' + DEFAULT_PORT + '/';
+    const DEFAULT_REDIRECT_URI = 'http://localhost:' + DEFAULT_PORT + '/';
     const DEFAULT_API_URI = 'https://api.pinterest.com';
     const DEFAULT_API_VERSION = 'v3'
     const DEFAULT_OAUTH_URI = 'https://www.pinterest.com';
     const DEFAULT_LANDING_URI = 'https://developers.pinterest.com/manage/';
-    const DEFAULT_KEY_FILE = 'localhost-key.pem';
-    const DEFAULT_CERT_FILE = 'localhost.pem';
     const DEFAULT_OAUTH_TOKEN_DIR = '.'
 
     // Get Pinterest application ID and secret from the OS environment.
@@ -28,8 +26,6 @@ export class ApiConfig {
     this.redirect_uri = DEFAULT_REDIRECT_URI
     this.landing_uri = process.env.REDIRECT_LANDING_URI || DEFAULT_LANDING_URI + this.app_id
 
-    this.https_key_file = process.env.HTTPS_KEY_FILE || DEFAULT_KEY_FILE
-    this.https_cert_file = process.env.HTTPS_CERT_FILE || DEFAULT_CERT_FILE
     this.oauth_token_dir = process.env.PINTEREST_OAUTH_TOKEN_DIR || DEFAULT_OAUTH_TOKEN_DIR
 
     // swizzle oauth and api hosts, based on environment

--- a/nodejs/src/api_config.test.js
+++ b/nodejs/src/api_config.test.js
@@ -21,10 +21,8 @@ describe('ApiConfig test environment', () => {
     expect(api_config.app_id).toEqual('test-app-id');
     expect(api_config.app_secret).toEqual('test-app-secret');
     expect(api_config.port).toEqual(8085);
-    expect(api_config.redirect_uri).toEqual('https://localhost:8085/');
+    expect(api_config.redirect_uri).toEqual('http://localhost:8085/');
     expect(api_config.landing_uri).toEqual('https://developers.pinterest.com/manage/test-app-id');
-    expect(api_config.https_key_file).toEqual('localhost-key.pem');
-    expect(api_config.https_cert_file).toEqual('localhost.pem');
     expect(api_config.oauth_uri).toEqual('https://www.pinterest.com');
     expect(api_config.api_uri).toEqual('https://api.pinterest.com');
     expect(api_config.version).toEqual('v3');
@@ -37,8 +35,6 @@ describe('ApiConfig test environment', () => {
     process.env.PINTEREST_APP_ID = 'test-app-id';
     process.env.PINTEREST_APP_SECRET = 'test-app-secret';
     process.env.REDIRECT_LANDING_URI = 'test-landing-uri';
-    process.env.HTTPS_KEY_FILE = 'test-https-key-file';
-    process.env.HTTPS_CERT_FILE = 'test-https-cert-file';
     process.env.PINTEREST_OAUTH_URI = 'test-oauth-uri';
     process.env.PINTEREST_API_URI = 'test-api-uri';
     process.env.PINTEREST_API_VERSION = 'test-api-version';
@@ -47,10 +43,8 @@ describe('ApiConfig test environment', () => {
     expect(api_config.app_id).toEqual('test-app-id');
     expect(api_config.app_secret).toEqual('test-app-secret');
     expect(api_config.port).toEqual(8085);
-    expect(api_config.redirect_uri).toEqual('https://localhost:8085/');
+    expect(api_config.redirect_uri).toEqual('http://localhost:8085/');
     expect(api_config.landing_uri).toEqual('test-landing-uri');
-    expect(api_config.https_key_file).toEqual('test-https-key-file');
-    expect(api_config.https_cert_file).toEqual('test-https-cert-file');
     expect(api_config.oauth_uri).toEqual('test-oauth-uri');
     expect(api_config.api_uri).toEqual('test-api-uri');
     expect(api_config.version).toEqual('test-api-version');

--- a/nodejs/src/user_auth.js
+++ b/nodejs/src/user_auth.js
@@ -1,4 +1,4 @@
-import https from 'https'
+import http from 'http'
 import fs from 'fs'
 import open from 'open'
 
@@ -6,17 +6,10 @@ export default async function get_auth_code(
   api_config, {scopes = null, refreshable = true}) {
   const auth_code = new Promise((resolve, reject) => {
 
-    // key and cert are required options for the https server.
-    const options = {
-      // Use mkcert to generate localhost.pem/localhost-key.pem key pair
-      key: fs.readFileSync(api_config.https_key_file),
-      cert: fs.readFileSync(api_config.https_cert_file)
-    };
-
     const sockets = []; // tracks the sockets connected to the server
 
-    // https is required to implement the Pinterest API redirect
-    const server = https.createServer(options, function (req, res) {
+    // http is required to implement the Pinterest API redirect
+    const server = http.createServer(function (req, res) {
       res.writeHead(301, {
         'Location': api_config.landing_uri
       })

--- a/python/README.md
+++ b/python/README.md
@@ -4,8 +4,7 @@ Python code that makes it easy to get started with the Pinterest API.
 
 ## Quick Start
 
-1. Follow the directions at the top level of this repo for configuring
-your application ID, application secret, and https certificates.
+1. Follow the directions at the top level of this repo for configuring your application ID and application secret.
 
 2. From the top of this repo, change your working directory to this directory: `cd python`
 
@@ -85,9 +84,6 @@ which is less secure than keeping the credentials in a file that you control.
      $ env | grep PINTEREST_APP
      PINTEREST_APP_ID=<number>
      PINTEREST_APP_SECRET=<string>
-     $ env | grep HTTPS
-     HTTPS_KEY_FILE=<path to key file>
-     HTTPS_CERT_FILE=<path to cert file>
      ```
 
    * Start PyCharm.

--- a/python/src/api_config.py
+++ b/python/src/api_config.py
@@ -9,7 +9,7 @@ from os.path import dirname, abspath, join
 # of ports that could be used in case some other service is listening on
 # the hard-coded port.
 DEFAULT_PORT = 8085
-DEFAULT_REDIRECT_URI = 'https://localhost:' + str(DEFAULT_PORT) + '/'
+DEFAULT_REDIRECT_URI = 'http://localhost:' + str(DEFAULT_PORT) + '/'
 DEFAULT_API_URI = 'https://api.pinterest.com'
 DEFAULT_API_VERSION = 'v3'
 DEFAULT_OAUTH_URI = 'https://www.pinterest.com'
@@ -32,8 +32,6 @@ class ApiConfig:
         self.landing_uri = os.environ.get('REDIRECT_LANDING_URI') or DEFAULT_LANDING_URI + self.app_id
 
         # locations of credentials in the file system
-        self.https_key_file = os.environ.get('HTTPS_KEY_FILE') or DEFAULT_KEY_FILE
-        self.https_cert_file = os.environ.get('HTTPS_CERT_FILE') or DEFAULT_CERT_FILE
         self.oauth_token_dir = os.environ.get('PINTEREST_OAUTH_TOKEN_DIR') or DEFAULT_OAUTH_TOKEN_DIR
 
         # swizzle oauth and api hosts, based on environment

--- a/python/src/api_config.py
+++ b/python/src/api_config.py
@@ -14,8 +14,6 @@ DEFAULT_API_URI = 'https://api.pinterest.com'
 DEFAULT_API_VERSION = 'v3'
 DEFAULT_OAUTH_URI = 'https://www.pinterest.com'
 DEFAULT_LANDING_URI = 'https://developers.pinterest.com/manage/'
-DEFAULT_KEY_FILE = 'localhost-key.pem'
-DEFAULT_CERT_FILE = 'localhost.pem'
 # OAuth tokens are in the current directory by default
 DEFAULT_OAUTH_TOKEN_DIR = '.'
 

--- a/python/src/user_auth.py
+++ b/python/src/user_auth.py
@@ -56,16 +56,6 @@ def get_auth_code(api_config, scopes=None, refreshable=True):
                             lambda request, address, server: HTTPServerHandler(
                                 request, address, server, api_config.landing_uri))
 
-    # Need SSL to support https, which is required for Pinterest API redirects
-    # Use mkcert to generate localhost.pem/localhost-key.pem key pair
-    try:
-        httpServer.socket = ssl.wrap_socket(httpServer.socket,
-                                            certfile=api_config.https_cert_file,
-                                            keyfile=api_config.https_key_file,
-                                            server_side=True)
-    except FileNotFoundError:
-        exit('ssl set up failed. Check the top-level README file for instructions regarding certificates.')
-
     # This function will block until it receives a request
     try:
         httpServer.handle_request()

--- a/python/tests/scripts/integration_mocks.py
+++ b/python/tests/scripts/integration_mocks.py
@@ -62,19 +62,8 @@ class IntegrationMocks(unittest.TestCase):
         self.monkeypatch(self.originals)
 
     # The integration tests start a web server on localhost and send a response to it.
-    # So, the https certificate set-up and an appropriate api_env are required.
-    # See the README file at the top-level of this repository for more information
-    # on the required set-up.
-    if not os.environ.get('HTTPS_KEY_FILE') or not os.environ.get('HTTPS_KEY_FILE'):
-        raise RuntimeError('HTTPS localhost certificate is required.' +
-                           ' See top-level README.' +
-                           ' Did you run the api_env script?')
-
     mock_os_environ = {'PINTEREST_APP_ID': 'test-app-id',
                        'PINTEREST_APP_SECRET': 'test-app-secret',
-                       'HTTPS_KEY_FILE': os.environ['HTTPS_KEY_FILE'],
-                       'HTTPS_CERT_FILE': os.environ['HTTPS_CERT_FILE'],
-                       'HTTPS_CA_BUNDLE': os.environ['HTTPS_CA_BUNDLE']
                        }
 
     
@@ -88,12 +77,10 @@ class IntegrationMocks(unittest.TestCase):
         def send_test_redirect():
             while True:
                 # use requests.request to avoid monkey-patched function
-                # HTTPS_CA_BUNDLE is set by the api_env script so that this
-                # test script can run with verified https.
                 response = requests.request(
                     'GET',
-                    'https://localhost:8085/?test-path&code=test-oauth-code',
-                    allow_redirects=False, verify=os.environ['HTTPS_CA_BUNDLE'])
+                    'http://localhost:8085/?test-path&code=test-oauth-code',
+                    allow_redirects=False)
                 print('response to redirect (301 expected): ' + str(response))
                 if response.ok:
                     return

--- a/python/tests/scripts/test_get_access_token.py
+++ b/python/tests/scripts/test_get_access_token.py
@@ -57,7 +57,7 @@ class GetAccessTokenTest(IntegrationMocks):
         # verify expected values printed. see unit tests for values
         mock_print.assert_any_call('mock_open_new: ' +
                                    'https://www.pinterest.com/oauth/?consumer_id=test-app-id' +
-                                   '&redirect_uri=https://localhost:8085/&response_type=code&' +
+                                   '&redirect_uri=http://localhost:8085/&response_type=code&' +
                                    'refreshable=True')
         mock_print.assert_any_call('hashed access token: ' +
                                    '597480d4b62ca612193f19e73fe4cc3ad17f0bf9cfc16a7cbf4b5064131c4805')

--- a/python/tests/src/test_api_config.py
+++ b/python/tests/src/test_api_config.py
@@ -14,18 +14,14 @@ class ApiConfigTest(unittest.TestCase):
         self.assertEqual(api_config.app_id, 'test-app-id')
         self.assertEqual(api_config.app_secret, 'test-app-secret')
         self.assertEqual(api_config.port, 8085)
-        self.assertEqual(api_config.redirect_uri, 'https://localhost:8085/')
+        self.assertEqual(api_config.redirect_uri, 'http://localhost:8085/')
         self.assertEqual(api_config.landing_uri, 'https://developers.pinterest.com/manage/test-app-id')
-        self.assertEqual(api_config.https_key_file, 'localhost-key.pem')
-        self.assertEqual(api_config.https_cert_file, 'localhost.pem')
         self.assertEqual(api_config.oauth_uri, 'https://www.pinterest.com')
         self.assertEqual(api_config.api_uri, 'https://api.pinterest.com')
 
     mock_os_environ_complete = {'PINTEREST_APP_ID': 'test-app-id',
                                 'PINTEREST_APP_SECRET': 'test-app-secret',
                                 'REDIRECT_LANDING_URI': 'test-landing-uri',
-                                'HTTPS_KEY_FILE': 'test-https-key-file',
-                                'HTTPS_CERT_FILE': 'test-https-cert-file',
                                 'PINTEREST_OAUTH_URI': 'test-oauth-uri',
                                 'PINTEREST_API_URI': 'test-api-uri'
                                 }
@@ -36,9 +32,7 @@ class ApiConfigTest(unittest.TestCase):
         self.assertEqual(api_config.app_id, 'test-app-id')
         self.assertEqual(api_config.app_secret, 'test-app-secret')
         self.assertEqual(api_config.port, 8085)
-        self.assertEqual(api_config.redirect_uri, 'https://localhost:8085/')
+        self.assertEqual(api_config.redirect_uri, 'http://localhost:8085/')
         self.assertEqual(api_config.landing_uri, 'test-landing-uri')
-        self.assertEqual(api_config.https_key_file, 'test-https-key-file')
-        self.assertEqual(api_config.https_cert_file, 'test-https-cert-file')
         self.assertEqual(api_config.oauth_uri, 'test-oauth-uri')
         self.assertEqual(api_config.api_uri, 'test-api-uri')

--- a/python/tests/src/test_user_auth.py
+++ b/python/tests/src/test_user_auth.py
@@ -7,10 +7,9 @@ from src.v3.oauth_scope import Scope
 
 class UserAuthTest(unittest.TestCase):
 
-    @mock.patch('src.user_auth.ssl.wrap_socket')
     @mock.patch('src.user_auth.HTTPServer')
     @mock.patch('src.user_auth.open_new')
-    def test_get_auth_code(self, mock_open_new, mock_http_server, mock_wrap_socket):
+    def test_get_auth_code(self, mock_open_new, mock_http_server):
 
         class MockHttpServer:
             def __init__(self):
@@ -27,24 +26,16 @@ class UserAuthTest(unittest.TestCase):
         mock_api_config.oauth_uri = 'test-oauth-uri'
         mock_api_config.app_id = 'test-app-id'
         mock_api_config.redirect_uri = 'test-redirect-uri'
-        mock_api_config.https_key_file = 'test-https-key-file'
-        mock_api_config.https_cert_file = 'test-https-cert-file'
         mock_access_uri = ('test-oauth-uri/oauth/' +
                            '?consumer_id=test-app-id' +
                            '&redirect_uri=test-redirect-uri' +
                            '&response_type=code' +
                            '&refreshable=True')
 
-        mock_wrap_socket.return_value = 'test-wrapped-socket'
-
         auth_code = get_auth_code(mock_api_config)
         mock_open_new.assert_called_once_with(mock_access_uri)
         mock_http_server.assert_called_once_with(('localhost', 'test-port'), mock.ANY)
-        mock_wrap_socket.assert_called_once_with('test-socket',
-                                                 certfile='test-https-cert-file',
-                                                 keyfile='test-https-key-file',
-                                                 server_side=True)
-        self.assertEqual(mock_http_server_instance.socket, 'test-wrapped-socket')
+        self.assertEqual(mock_http_server_instance.socket, 'test-socket')
         self.assertEqual(auth_code, 'test-auth-code')
 
         # verify calling get_auth_code with non-default values


### PR DESCRIPTION
The OAuth 2.0 RFC specifies that http://localhost:<port>/ is a valid redirect URI, and the Pinterest API now supports the http protocol with localhost. This pull request switches the redirect URI from https://localhost:8085 to http://localhost:8085.