### PR TITLE
support version-specific OAuth

### DIFF
--- a/bash/scripts/get_access_token.sh
+++ b/bash/scripts/get_access_token.sh
@@ -1,100 +1,16 @@
 #!/usr/bin/env bash
-
 #
-# This script uses curl, openssl, and some helper utilities to demonstrate how to
-# use OAuth authentication with the Pinterest API.
+# OAuth is version specific, so this script just calls the appropriate
+# version-specific script, based on the PINTEREST_API_VERSION environment
+# variable. More documentation is available in each version-specific script.
 #
-# To see the communications at any stage of this script, use echo to show the
-# relevant variable. For example, echo "$REDIRECT_SESSION" to see the complete
-# web browser session for the redirect.
-# 
-# Prerequisites: curl, openssl, base64, jq, grep, cut
-#
+: ${PINTEREST_API_VERSION:=v3}
 
-# Get configuration from environment or defaults.
-: ${REDIRECT_PORT:=8085}
-: ${PINTEREST_API_URI:=https://api.pinterest.com}
-: ${PINTEREST_OAUTH_URI:=https://www.pinterest.com}
-: ${REDIRECT_LANDING_URI:=https://developers.pinterest.com/manage/${PINTEREST_APP_ID}}
-REDIRECT_URI="http://localhost:${REDIRECT_PORT}/"
+SCRIPT_NAME="${BASH_SOURCE[0]}"
 
-# Note that the application id and secrect have no defaults,
-# because it is best practice not to store credentials in code.
-B64AUTH=$(echo -n "${PINTEREST_APP_ID}:${PINTEREST_APP_SECRET}" | base64)
+# get the location of this script
+SCRIPT_DIR=$(cd $(dirname ${SCRIPT_NAME}); pwd)
 
-# Get the authorization code by starting a browser session and handling the redirect.
-echo 'getting auth_code...'
-
-# Specify the scopes for the user to authorize via OAuth.
-# This example requests typical read-only authorization.
-# For more information, see: https://developers.pinterest.com/docs/redoc/#section/User-Authorization/OAuth-scopes
-SCOPE=read_users
-
-# This call opens the browser with the oauth information in the URI.
-open "${PINTEREST_OAUTH_URI}/oauth/?consumer_id=${PINTEREST_APP_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&response_type=code" &
-
-# 1. Use netcat (nc) to run the web browser to handle the redirect from the oauth call.
-# 2. Wait for the response.
-# 3. Redirect using a HTTP 301 response to the landing URI.
-REDIRECT_SESSION=$(nc -l localhost ${REDIRECT_PORT} 2>&1 <<EOF
-HTTP/1.1 301 Moved Permanently
-Location: ${REDIRECT_LANDING_URI}
-
-EOF
-)
-
-# Cut the authorization code from the output of the web server, which includes
-# the redirect URI with the authorization code.
-AUTH_CODE=$(echo "${REDIRECT_SESSION}" | grep GET | cut -d ' ' -f 2 | cut -d '=' -f 2)
-
-# Exchange the authorization code for the access token.
-echo 'exchanging auth_code for access_token...'
-
-# Construct the data for the PUT via curl.
-PUT_DATA="{\"code\": \"${AUTH_CODE}\", \"redirect_uri\": \"${REDIRECT_URI}\", \"grant_type\": \"authorization_code\"}"
-
-# Execute the curl PUT command to exchange the authorization code for the access token.
-# 1. Use basic authorization (constructed above) with the application id and secret.
-# 2. Note that it is necessary to specify JSON as the content type.
-OAUTH_RESPONSE=$(curl --silent -X PUT --header "Authorization:Basic ${B64AUTH}" --header 'Content-Type: application/json' --data "${PUT_DATA}" "${PINTEREST_API_URI}/v3/oauth/access_token/")
-
-# An alternative for the above command is to use the basic authentication
-# that is built into curl. Replace these arguments:
-#   --header "Authorization:Basic ${B64AUTH}"
-# with these arguments:
-#   --basic --user "${PINTEREST_APP_ID}:${PINTEREST_APP_SECRET}"
-
-STATUS=$(echo "$OAUTH_RESPONSE" | jq -r '.["status"]')
-echo status: $STATUS
-
-# Parse the JSON returned by the exchange call and retrieve the access token.
-ACCESS_TOKEN=$(echo "$OAUTH_RESPONSE" | jq -r '.["access_token"]')
-
-# The scope returned in the response includes all of the scopes that
-# have been approved now or in the past by the user.
-SCOPE=$(echo "$OAUTH_RESPONSE" | jq -r '.["scope"]')
-echo scope: $SCOPE
-
-# Demonstrate how to use the access token to get information about the associated user.
-echo 'getting user data using the access token'
-USER_RESPONSE=$(curl --silent -X GET --header "Authorization:Bearer ${ACCESS_TOKEN}" "${PINTEREST_API_URI}/v3/users/me/")
-
-# An alternative for the above command is to use the OAuth2 bearer authentication
-# that is built into curl. Replace these arguments:
-#   --header "Authorization:Bearer ${ACCESS_TOKEN}"
-# with these arguments:
-#   --oauth2-bearer "${ACCESS_TOKEN}"
-
-# Parse the JSON response and print the data associated with the user.
-USER_ID=$(echo ${USER_RESPONSE} | jq -r '.["data"]["id"]')
-FULL_NAME=$(echo ${USER_RESPONSE} | jq -r '.["data"]["full_name"]')
-ABOUT=$(echo ${USER_RESPONSE} | jq -r '.["data"]["about"]')
-PROFILE_URL=$(echo ${USER_RESPONSE} | jq -r '.["data"]["profile_url"]')
-PIN_COUNT=$(echo ${USER_RESPONSE} | jq -r '.["data"]["pin_count"]')
-echo '--- User Summary ---'
-echo ID: $USER_ID
-echo Full Name: $FULL_NAME
-echo About: $ABOUT
-echo Profile URL: $PROFILE_URL
-echo Pin Count: $PIN_COUNT
-echo '--------------------'
+VERSION_SPECIFIC_SCRIPT="${SCRIPT_DIR}/${PINTEREST_API_VERSION}/get_access_token.sh"
+echo running version specific script: ${VERSION_SPECIFIC_SCRIPT}
+exec ${VERSION_SPECIFIC_SCRIPT}

--- a/bash/scripts/v3/get_access_token.sh
+++ b/bash/scripts/v3/get_access_token.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+#
+# This script uses curl, openssl, and some helper utilities to demonstrate how to
+# use OAuth authentication with the Pinterest API.
+#
+# To see the communications at any stage of this script, use echo to show the
+# relevant variable. For example, echo "$REDIRECT_SESSION" to see the complete
+# web browser session for the redirect.
+#
+# Prerequisites: curl, openssl, base64, jq, grep, cut
+#
+
+# Get configuration from environment or defaults.
+: ${REDIRECT_PORT:=8085}
+: ${PINTEREST_API_URI:=https://api.pinterest.com}
+: ${PINTEREST_OAUTH_URI:=https://www.pinterest.com}
+: ${REDIRECT_LANDING_URI:=https://developers.pinterest.com/manage/${PINTEREST_APP_ID}}
+REDIRECT_URI="http://localhost:${REDIRECT_PORT}/"
+
+# Note that the application id and secrect have no defaults,
+# because it is best practice not to store credentials in code.
+B64AUTH=$(echo -n "${PINTEREST_APP_ID}:${PINTEREST_APP_SECRET}" | base64)
+
+# Get the authorization code by starting a browser session and handling the redirect.
+echo 'getting auth_code...'
+
+# Specify the scopes for the user to authorize via OAuth.
+# This example requests typical read-only authorization.
+# For more information, see: https://developers.pinterest.com/docs/redoc/#section/User-Authorization/OAuth-scopes
+SCOPE=read_users
+
+# This call opens the browser with the oauth information in the URI.
+open "${PINTEREST_OAUTH_URI}/oauth/?consumer_id=${PINTEREST_APP_ID}&redirect_uri=${REDIRECT_URI}&scope=${SCOPE}&response_type=code" &
+
+# 1. Use netcat (nc) to run the web browser to handle the redirect from the oauth call.
+# 2. Wait for the response.
+# 3. Redirect using a HTTP 301 response to the landing URI.
+REDIRECT_SESSION=$(nc -l localhost ${REDIRECT_PORT} 2>&1 <<EOF
+HTTP/1.1 301 Moved Permanently
+Location: ${REDIRECT_LANDING_URI}
+
+EOF
+)
+
+# Cut the authorization code from the output of the web server, which includes
+# the redirect URI with the authorization code.
+AUTH_CODE=$(echo "${REDIRECT_SESSION}" | grep GET | cut -d ' ' -f 2 | cut -d '=' -f 2)
+
+# Exchange the authorization code for the access token.
+echo 'exchanging auth_code for access_token...'
+
+# Construct the data for the PUT via curl.
+PUT_DATA="{\"code\": \"${AUTH_CODE}\", \"redirect_uri\": \"${REDIRECT_URI}\", \"grant_type\": \"authorization_code\"}"
+
+# Execute the curl PUT command to exchange the authorization code for the access token.
+# 1. Use basic authorization (constructed above) with the application id and secret.
+# 2. Note that it is necessary to specify JSON as the content type.
+OAUTH_RESPONSE=$(curl --silent -X PUT --header "Authorization:Basic ${B64AUTH}" --header 'Content-Type: application/json' --data "${PUT_DATA}" "${PINTEREST_API_URI}/v3/oauth/access_token/")
+
+# An alternative for the above command is to use the basic authentication
+# that is built into curl. Replace these arguments:
+#   --header "Authorization:Basic ${B64AUTH}"
+# with these arguments:
+#   --basic --user "${PINTEREST_APP_ID}:${PINTEREST_APP_SECRET}"
+
+STATUS=$(echo "$OAUTH_RESPONSE" | jq -r '.["status"]')
+echo status: $STATUS
+
+# Parse the JSON returned by the exchange call and retrieve the access token.
+ACCESS_TOKEN=$(echo "$OAUTH_RESPONSE" | jq -r '.["access_token"]')
+
+# The scope returned in the response includes all of the scopes that
+# have been approved now or in the past by the user.
+SCOPE=$(echo "$OAUTH_RESPONSE" | jq -r '.["scope"]')
+echo scope: $SCOPE
+
+# Demonstrate how to use the access token to get information about the associated user.
+echo 'getting user data using the access token'
+USER_RESPONSE=$(curl --silent -X GET --header "Authorization:Bearer ${ACCESS_TOKEN}" "${PINTEREST_API_URI}/v3/users/me/")
+
+# An alternative for the above command is to use the OAuth2 bearer authentication
+# that is built into curl. Replace these arguments:
+#   --header "Authorization:Bearer ${ACCESS_TOKEN}"
+# with these arguments:
+#   --oauth2-bearer "${ACCESS_TOKEN}"
+
+# Parse the JSON response and print the data associated with the user.
+USER_ID=$(echo ${USER_RESPONSE} | jq -r '.["data"]["id"]')
+FULL_NAME=$(echo ${USER_RESPONSE} | jq -r '.["data"]["full_name"]')
+ABOUT=$(echo ${USER_RESPONSE} | jq -r '.["data"]["about"]')
+PROFILE_URL=$(echo ${USER_RESPONSE} | jq -r '.["data"]["profile_url"]')
+PIN_COUNT=$(echo ${USER_RESPONSE} | jq -r '.["data"]["pin_count"]')
+echo '--- User Summary ---'
+echo ID: $USER_ID
+echo Full Name: $FULL_NAME
+echo About: $ABOUT
+echo Profile URL: $PROFILE_URL
+echo Pin Count: $PIN_COUNT
+echo '--------------------'

--- a/common/scripts/api_app_credentials.template
+++ b/common/scripts/api_app_credentials.template
@@ -6,7 +6,7 @@ export PINTEREST_APP_ID="App ID goes here"
 export PINTEREST_APP_SECRET="App secret goes here"
 
 # Note: If the App ID and App secret are specified in version-specific
-# enviroment variables like PINTEREST_V3_APP_ID and PINTEREST_V3_APP_SECRET,
+# environment variables like PINTEREST_V3_APP_ID and PINTEREST_V3_APP_SECRET,
 # the version-specific information overrides information in the generic
 # variables PINTEREST_APP_ID and PINTEREST_APP_SECRET. This feature makes
 # it easier to use different application credentials with different API versions.

--- a/common/scripts/api_app_credentials.template
+++ b/common/scripts/api_app_credentials.template
@@ -5,3 +5,8 @@
 export PINTEREST_APP_ID="App ID goes here"
 export PINTEREST_APP_SECRET="App secret goes here"
 
+# Note: If the App ID and App secret are specified in version-specific
+# enviroment variables like PINTEREST_V3_APP_ID and PINTEREST_V3_APP_SECRET,
+# the version-specific information overrides information in the generic
+# variables PINTEREST_APP_ID and PINTEREST_APP_SECRET. This feature makes
+# it easier to use different application credentials with different API versions.

--- a/nodejs/scripts/copy_board.js
+++ b/nodejs/scripts/copy_board.js
@@ -9,7 +9,6 @@
  */
 import {ArgumentParser} from 'argparse'
 
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 import {SpamError} from '../src/api_common.js'
 
@@ -92,6 +91,7 @@ async function main (argv) {
   api_config.verbosity = 2;
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {Board} = await import(`../src/${api_config.version}/board.js`);
   const {Pin} = await import(`../src/${api_config.version}/pin.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);

--- a/nodejs/scripts/copy_pin.js
+++ b/nodejs/scripts/copy_pin.js
@@ -9,7 +9,6 @@
  */
 import {ArgumentParser} from 'argparse'
 
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 
 /**
@@ -35,6 +34,7 @@ async function main (argv) {
   api_config.verbosity = 2;
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {Pin} = await import(`../src/${api_config.version}/pin.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);
 

--- a/nodejs/scripts/delete_board.js
+++ b/nodejs/scripts/delete_board.js
@@ -5,7 +5,6 @@
  */
 import {ArgumentParser} from 'argparse'
 
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 import {Input} from '../src/utils.js'
 
@@ -34,6 +33,7 @@ async function main (argv) {
   api_config.verbosity = 2;
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {Board} = await import(`../src/${api_config.version}/board.js`);
   const {User} = await import(`../src/${api_config.version}/user.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);

--- a/nodejs/scripts/get_access_token.js
+++ b/nodejs/scripts/get_access_token.js
@@ -61,7 +61,13 @@ async function main (argv) {
   } else {
     // Try the different methods for getting an access token: from the environment,
     // from a file, and from Pinterest via the browser.
-    await access_token.fetch({});
+    try {
+      await access_token.fetch({});
+    } catch (error) { // probably because scopes are required
+      console.log(error);
+      parser.print_usage();
+      process.exit(1);
+    }
   }
 
   // Note: It is best practice not to print credentials in clear text.

--- a/nodejs/scripts/get_access_token.js
+++ b/nodejs/scripts/get_access_token.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import {ArgumentParser} from 'argparse'
 
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 
 /**
@@ -40,6 +39,7 @@ async function main (argv) {
   api_config.verbosity = 2;
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {User} = await import(`../src/${api_config.version}/user.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);
 

--- a/nodejs/scripts/get_board.js
+++ b/nodejs/scripts/get_board.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import {ArgumentParser} from 'argparse'
 
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 
 /**
@@ -21,6 +20,7 @@ async function main (argv) {
   api_config.verbosity = 2;
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {Board} = await import(`../src/${api_config.version}/board.js`);
   const {Pin} = await import(`../src/${api_config.version}/pin.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);

--- a/nodejs/scripts/get_businesses.js
+++ b/nodejs/scripts/get_businesses.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 
 async function main () {
@@ -7,6 +6,7 @@ async function main () {
   const api_config = new ApiConfig();
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);
   const {User} = await import(`../src/${api_config.version}/user.js`);
 

--- a/nodejs/scripts/get_pin.js
+++ b/nodejs/scripts/get_pin.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import {ArgumentParser} from 'argparse'
 
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 
 /**
@@ -20,6 +19,7 @@ async function main (argv) {
   api_config.verbosity = 2;
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {Pin} = await import(`../src/${api_config.version}/pin.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);
 

--- a/nodejs/scripts/get_user_boards.js
+++ b/nodejs/scripts/get_user_boards.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import {ArgumentParser} from 'argparse'
 
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 
 /**
@@ -30,6 +29,7 @@ async function main (argv) {
   api_config.verbosity = 2;
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {Board} = await import(`../src/${api_config.version}/board.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);
   const {User} = await import(`../src/${api_config.version}/user.js`);

--- a/nodejs/scripts/get_user_pins.js
+++ b/nodejs/scripts/get_user_pins.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import {ArgumentParser} from 'argparse'
 
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 
 /**
@@ -22,6 +21,7 @@ async function main (argv) {
   api_config.verbosity = 2;
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {Pin} = await import(`../src/${api_config.version}/pin.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);
   const {User} = await import(`../src/${api_config.version}/user.js`);

--- a/nodejs/scripts/refresh_access_token.js
+++ b/nodejs/scripts/refresh_access_token.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import {ArgumentParser} from 'argparse'
 
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 
 /**
@@ -19,6 +18,7 @@ async function main (argv) {
   api_config.verbosity = 2;
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {User} = await import(`../src/${api_config.version}/user.js`);
 
   const access_token = new AccessToken(api_config, {});

--- a/nodejs/scripts/refresh_example.js
+++ b/nodejs/scripts/refresh_example.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import {AccessToken} from '../src/access_token.js'
 import {ApiConfig} from '../src/api_config.js'
 
 async function main () {
@@ -7,6 +6,7 @@ async function main () {
   const api_config = new ApiConfig();
 
   // imports that depend on the version of the API
+  const {AccessToken} = await import(`../src/${api_config.version}/access_token.js`);
   const {Scope} = await import(`../src/${api_config.version}/oauth_scope.js`);
   const {User} = await import(`../src/${api_config.version}/user.js`);
 

--- a/nodejs/src/access_token_common.js
+++ b/nodejs/src/access_token_common.js
@@ -1,11 +1,8 @@
 import crypto from 'crypto'
 import fs from 'fs';
-import got from 'got'
 import path from 'path'
 
-import get_auth_code from './user_auth.js'
-
-export class AccessToken {
+export class AccessTokenCommon {
 
   constructor(api_config, {name = null}) {
     const auth = api_config.app_id + ':' + api_config.app_secret;
@@ -61,41 +58,7 @@ export class AccessToken {
 
   // constructor may not be async, so OAuth must be performed as a separate method.
   async oauth({scopes=null, refreshable=true}) {
-    console.log('getting auth_code...');
-    const auth_code = await get_auth_code(this.api_config,
-                                          {scopes:scopes, refreshable:refreshable});
-
-    console.log('exchanging auth_code for access_token...');
-    var response;
-    try {
-      response = await got.put(this.api_uri + '/v3/oauth/access_token/', {
-        headers: this.auth_headers, // use the recommended authorization approach
-        json: {
-          'code': auth_code,
-          'redirect_uri': this.api_config.redirect_uri,
-          'grant_type': 'authorization_code'
-        },
-        responseType: 'json'
-      })
-    } catch (error) {
-      console.log(`<Response [${error.response.statusCode}]>`);
-      console.log('request failed with reason:', error.response.body.message);
-      throw 'OAuth failed because... ' + error.response.body.message;
-    }
-
-    console.log(`<Response [${response.statusCode}]>`);
-    console.log('status: ' + response.body.status);
-    if (this.api_config.verbosity >= 3) {
-      console.log('x-pinterest-rid:', response.headers['x-pinterest-rid']);
-    }
-    // The scope returned in the response includes all of the scopes that
-    // have been approved now or in the past by the user.
-    console.log('scope: ' + response.body.scope);
-    this.access_token = response.body.access_token;
-    this.refresh_token = response.body.data.refresh_token;
-    if (this.refresh_token) {
-      console.log('received refresh token');
-    }
+    console.log('refresh() must be overriden.')
   }
 
   /**
@@ -168,28 +131,6 @@ export class AccessToken {
   }
 
   async refresh() {
-    // There should be a refresh_token, but it is best to check.
-    if (!this.refresh_token) {
-      throw 'AccessToken does not have a refresh token';
-    }
-
-    console.log('refreshing access_token...');
-    var response;
-    try {
-      response = await got.put(this.api_uri + '/v3/oauth/access_token/', {
-        headers: this.auth_headers,
-        json: {
-          'grant_type': 'refresh_token',
-          'refresh_token': this.refresh_token
-        },
-        responseType: 'json'
-      })
-    } catch (error) {
-      console.log(`<Response [${error.response.statusCode}]>`);
-      console.log('request failed with reason:', error.response.body.message);
-      throw 'AccessToken refresh failed because... ' + error.response.body.message;
-    }
-    console.log(`<Response [${response.statusCode}]>`);
-    this.access_token = response.body.access_token;
+    console.log('refresh() must be overriden.')
   }
 }

--- a/nodejs/src/api_config.test.js
+++ b/nodejs/src/api_config.test.js
@@ -13,6 +13,9 @@ describe('ApiConfig test environment', () => {
   });
 
   test('API configuration from defaults', () => {
+    // check output
+    console.log = jest.fn();
+
     // minimal environment
     process.env.PINTEREST_APP_ID = 'test-app-id';
     process.env.PINTEREST_APP_SECRET = 'test-app-secret';
@@ -26,9 +29,14 @@ describe('ApiConfig test environment', () => {
     expect(api_config.oauth_uri).toEqual('https://www.pinterest.com');
     expect(api_config.api_uri).toEqual('https://api.pinterest.com');
     expect(api_config.version).toEqual('v3');
+    expect(console.log.mock.calls[0][0]).toEqual(
+      'Using application ID and secret from PINTEREST_APP_ID and PINTEREST_APP_SECRET.');
   });
 
   test('environment API environment', () => {
+    // check output
+    console.log = jest.fn();
+
     // minimal environment
     process.env.PINTEREST_APP_ID = 'test-app-id';
     process.env.PINTEREST_APP_SECRET = 'test-app-secret';
@@ -48,5 +56,7 @@ describe('ApiConfig test environment', () => {
     expect(api_config.oauth_uri).toEqual('test-oauth-uri');
     expect(api_config.api_uri).toEqual('test-api-uri');
     expect(api_config.version).toEqual('test-api-version');
+    expect(console.log.mock.calls[0][0]).toEqual(
+      'Using application ID and secret from PINTEREST_APP_ID and PINTEREST_APP_SECRET.');
   });
 });

--- a/nodejs/src/v3/access_token.js
+++ b/nodejs/src/v3/access_token.js
@@ -1,0 +1,76 @@
+import got from 'got'
+
+import {AccessTokenCommon} from '../access_token_common.js'
+import get_auth_code from '../user_auth.js'
+
+export class AccessToken extends AccessTokenCommon {
+
+  constructor(api_config, {name = null}) {
+    super(api_config, {name: name});
+  }
+
+  // constructor may not be async, so OAuth must be performed as a separate method.
+  async oauth({scopes=null, refreshable=true}) {
+    console.log('getting auth_code...');
+    const auth_code = await get_auth_code(this.api_config,
+                                          {scopes:scopes, refreshable:refreshable});
+
+    console.log('exchanging auth_code for access_token...');
+    var response;
+    try {
+      response = await got.put(this.api_uri + '/v3/oauth/access_token/', {
+        headers: this.auth_headers, // use the recommended authorization approach
+        json: {
+          'code': auth_code,
+          'redirect_uri': this.api_config.redirect_uri,
+          'grant_type': 'authorization_code'
+        },
+        responseType: 'json'
+      })
+    } catch (error) {
+      console.log(`<Response [${error.response.statusCode}]>`);
+      console.log('request failed with reason:', error.response.body.message);
+      throw 'OAuth failed because... ' + error.response.body.message;
+    }
+
+    console.log(`<Response [${response.statusCode}]>`);
+    console.log('status: ' + response.body.status);
+    if (this.api_config.verbosity >= 3) {
+      console.log('x-pinterest-rid:', response.headers['x-pinterest-rid']);
+    }
+    // The scope returned in the response includes all of the scopes that
+    // have been approved now or in the past by the user.
+    console.log('scope: ' + response.body.scope);
+    this.access_token = response.body.access_token;
+    this.refresh_token = response.body.data.refresh_token;
+    if (this.refresh_token) {
+      console.log('received refresh token');
+    }
+  }
+
+  async refresh() {
+    // There should be a refresh_token, but it is best to check.
+    if (!this.refresh_token) {
+      throw 'AccessToken does not have a refresh token';
+    }
+
+    console.log('refreshing access_token...');
+    var response;
+    try {
+      response = await got.put(this.api_uri + '/v3/oauth/access_token/', {
+        headers: this.auth_headers,
+        json: {
+          'grant_type': 'refresh_token',
+          'refresh_token': this.refresh_token
+        },
+        responseType: 'json'
+      })
+    } catch (error) {
+      console.log(`<Response [${error.response.statusCode}]>`);
+      console.log('request failed with reason:', error.response.body.message);
+      throw 'AccessToken refresh failed because... ' + error.response.body.message;
+    }
+    console.log(`<Response [${response.statusCode}]>`);
+    this.access_token = response.body.access_token;
+  }
+}

--- a/nodejs/src/v3/access_token.js
+++ b/nodejs/src/v3/access_token.js
@@ -18,6 +18,9 @@ export class AccessToken extends AccessTokenCommon {
     console.log('exchanging auth_code for access_token...');
     var response;
     try {
+      if (this.api_config.verbosity >= 2) {
+        console.log('PUT', this.api_uri + '/v3/oauth/access_token/');
+      }
       response = await got.put(this.api_uri + '/v3/oauth/access_token/', {
         headers: this.auth_headers, // use the recommended authorization approach
         json: {
@@ -57,6 +60,9 @@ export class AccessToken extends AccessTokenCommon {
     console.log('refreshing access_token...');
     var response;
     try {
+      if (this.api_config.verbosity >= 2) {
+        console.log('PUT', this.api_uri + '/v3/oauth/access_token/');
+      }
       response = await got.put(this.api_uri + '/v3/oauth/access_token/', {
         headers: this.auth_headers,
         json: {

--- a/nodejs/src/v3/access_token.test.js
+++ b/nodejs/src/v3/access_token.test.js
@@ -1,9 +1,9 @@
 import {AccessToken} from './access_token.js'
-import {Scope} from './v3/oauth_scope.js'
-import get_auth_code from './user_auth.js'
+import {Scope} from './oauth_scope.js'
+import get_auth_code from '../user_auth.js'
 import got from 'got'
 
-jest.mock('./user_auth');
+jest.mock('../user_auth');
 jest.mock('got');
 
 describe('access_token tests', () => {

--- a/python/scripts/analytics_api_example.py
+++ b/python/scripts/analytics_api_example.py
@@ -5,7 +5,6 @@ import sys
 
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
-from access_token import AccessToken
 from api_config import ApiConfig
 from arguments import common_arguments
 from generic_requests import download_file
@@ -45,6 +44,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from advertisers import Advertisers
     from delivery_metrics import DeliveryMetrics
     from delivery_metrics import DeliveryMetricsAsyncReport

--- a/python/scripts/copy_board.py
+++ b/python/scripts/copy_board.py
@@ -15,7 +15,6 @@ sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_common import SpamException
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 
 def main(argv=[]):
@@ -91,6 +90,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from board import Board
     from oauth_scope import Scope
     from pin import Pin

--- a/python/scripts/copy_pin.py
+++ b/python/scripts/copy_pin.py
@@ -14,7 +14,6 @@ import sys
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 
 def main(argv=[]):
@@ -38,6 +37,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from oauth_scope import Scope
     from pin import Pin
 

--- a/python/scripts/delete_board.py
+++ b/python/scripts/delete_board.py
@@ -10,7 +10,6 @@ import sys
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 from utils import input_one_of
 
@@ -36,6 +35,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from board import Board
     from oauth_scope import Scope
     from user import User

--- a/python/scripts/get_access_token.py
+++ b/python/scripts/get_access_token.py
@@ -60,7 +60,13 @@ def main(argv=[]):
         scopes = list(map(lambda arg: Scope[arg.upper()], args.scopes.split(',')))
         access_token.oauth(scopes=scopes)
     else:
-        access_token.fetch()
+        try:
+            access_token.fetch()
+        except ValueError as err:
+            # ValueError indicates that something was wrong with the arguments
+            print(err)
+            parser.print_usage()
+            exit(1)
 
     # Note: It is best practice not to print credentials in clear text.
     # Pinterest engineers asked for this capability to make it easier to support partners.

--- a/python/scripts/get_access_token.py
+++ b/python/scripts/get_access_token.py
@@ -6,7 +6,6 @@ import sys
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 
 def main(argv=[]):
@@ -48,6 +47,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from oauth_scope import Scope
     from user import User
 

--- a/python/scripts/get_board.py
+++ b/python/scripts/get_board.py
@@ -6,7 +6,6 @@ import sys
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 
 def main(argv=[]):
@@ -28,6 +27,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from board import Board
     from oauth_scope import Scope
     from pin import Pin

--- a/python/scripts/get_businesses.py
+++ b/python/scripts/get_businesses.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 from os.path import dirname, abspath, join
+import argparse
 import sys
 
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 
 def main(argv=[]):
@@ -26,6 +26,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from oauth_scope import Scope
     from user import User
 

--- a/python/scripts/get_pin.py
+++ b/python/scripts/get_pin.py
@@ -6,7 +6,6 @@ import sys
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 
 def main(argv=[]):
@@ -23,6 +22,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from oauth_scope import Scope
     from pin import Pin
 

--- a/python/scripts/get_user_boards.py
+++ b/python/scripts/get_user_boards.py
@@ -6,7 +6,6 @@ import sys
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 from arguments import positive_integer
 
@@ -33,6 +32,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from board import Board
     from oauth_scope import Scope
     from user import User

--- a/python/scripts/get_user_pins.py
+++ b/python/scripts/get_user_pins.py
@@ -6,7 +6,6 @@ import sys
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 from arguments import positive_integer
 
@@ -26,6 +25,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from oauth_scope import Scope
     from pin import Pin
     from user import User

--- a/python/scripts/refresh_access_token.py
+++ b/python/scripts/refresh_access_token.py
@@ -6,7 +6,6 @@ import sys
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 
 def main(argv=[]):
@@ -24,6 +23,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from user import User
 
     access_token = AccessToken(api_config, name=args.access_token)

--- a/python/scripts/refresh_example.py
+++ b/python/scripts/refresh_example.py
@@ -7,7 +7,6 @@ import time
 sys.path.append(abspath(join(dirname(__file__), '..', 'src')))
 
 from api_config import ApiConfig
-from access_token import AccessToken
 from arguments import common_arguments
 
 def main(argv=[]):
@@ -26,6 +25,7 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # imports that depend on the version of the API
+    from access_token import AccessToken
     from user import User
 
     # Note: It's possible to use the same API configuration with

--- a/python/src/access_token_common.py
+++ b/python/src/access_token_common.py
@@ -3,9 +3,6 @@ import hashlib
 import json
 import os
 import pathlib
-import requests
-
-import user_auth
 
 class AccessTokenCommon:
     def __init__(self, api_config, name=None):
@@ -53,17 +50,7 @@ class AccessTokenCommon:
         self.oauth(scopes=scopes, refreshable=refreshable)
 
     def oauth(self, scopes=None, refreshable=True):
-        """
-        Execute the OAuth 2.0 process for obtaining an access token.
-        For more information, see IETF RFC 6749: https://tools.ietf.org/html/rfc6749
-        """
-        print('getting auth_code...')
-        auth_code = user_auth.get_auth_code(self.api_config, scopes=scopes, refreshable=refreshable)
-        print(f'exchanging auth_code for {self.name}...')
-        self.exchange_auth_code(auth_code)
-
-    def exchange_auth_code(self, auth_code):
-        print('exchange_auth_code must be overridden.')
+        print('oauth() must be overridden')
 
     def from_environment(self):
         """

--- a/python/src/access_token_common.py
+++ b/python/src/access_token_common.py
@@ -7,7 +7,7 @@ import requests
 
 import user_auth
 
-class AccessToken:
+class AccessTokenCommon:
     def __init__(self, api_config, name=None):
 
         if name:
@@ -60,36 +60,10 @@ class AccessToken:
         print('getting auth_code...')
         auth_code = user_auth.get_auth_code(self.api_config, scopes=scopes, refreshable=refreshable)
         print(f'exchanging auth_code for {self.name}...')
-        self._exchange_auth_code(auth_code)
+        self.exchange_auth_code(auth_code)
 
-    def _exchange_auth_code(self, auth_code):
-        """
-        Call the Pinterest API to exchange the auth_code (obtained by
-        a redirect from the browser) for the access_token and (if requested)
-        refresh_token.
-        """
-        put_data = {'code': auth_code,
-                    'redirect_uri': self.api_config.redirect_uri,
-                    'grant_type': 'authorization_code'}
-        if (self.api_config.verbosity >= 2):
-            print('PUT', self.api_config.api_uri + '/v3/oauth/access_token/')
-        response = requests.put(self.api_config.api_uri + '/v3/oauth/access_token/',
-                                headers=self.auth_headers, data=put_data)
-        print(response)
-        respdict = response.json()
-        print('status: ' + respdict['status'])
-        if (self.api_config.verbosity >= 3):
-            print('x-pinterest-rid:', response.headers.get('x-pinterest-rid'))
-        """
-        The scope returned in the response includes all of the scopes that
-        have been approved now or in the past by the user.
-        """
-        print('scope: ' + respdict['scope'])
-        self.access_token = respdict['access_token']
-        self.refresh_token = respdict['data'].get('refresh_token')
-        self.scopes = respdict['scope']
-        if self.refresh_token:
-            print('received refresh token')
+    def exchange_auth_code(self, auth_code):
+        print('exchange_auth_code must be overridden.')
 
     def from_environment(self):
         """
@@ -151,16 +125,4 @@ class AccessToken:
         return hashlib.sha256(self.refresh_token.encode()).hexdigest()
 
     def refresh(self):
-        if not self.refresh_token:
-            raise RuntimeError('AccessToken does not have a refresh token')
-        print(f'refreshing {self.name}...')
-        put_data = {'grant_type': 'refresh_token',
-                    'refresh_token': self.refresh_token}
-        if (self.api_config.verbosity >= 2):
-            print('PUT', self.api_config.api_uri + '/v3/oauth/access_token/')
-        response = requests.put(self.api_config.api_uri + '/v3/oauth/access_token/',
-                                headers=self.auth_headers, data=put_data)
-        print(response)
-        if (self.api_config.verbosity >= 3):
-            print('x-pinterest-rid:', response.headers.get('x-pinterest-rid'))
-        self.access_token = response.json()['access_token']
+        print('refresh() must be overridden.')

--- a/python/src/api_config.py
+++ b/python/src/api_config.py
@@ -19,6 +19,9 @@ DEFAULT_OAUTH_TOKEN_DIR = '.'
 
 class ApiConfig:
     def __init__(self, verbosity=2, version=None):
+        # Set logging output (verbosity) level
+        self.verbosity = verbosity
+
         # Get Pinterest API version from the command line, environment, or above default.
         if (version):
             self.version = 'v' + str(version)
@@ -40,16 +43,14 @@ class ApiConfig:
         self.oauth_uri = os.environ.get('PINTEREST_OAUTH_URI') or DEFAULT_OAUTH_URI
         self.api_uri = os.environ.get('PINTEREST_API_URI') or DEFAULT_API_URI
 
-        # default level of verbosity, probably should switch to logging
-        self.verbosity = verbosity
-
         # set up to load the code modules for this version of the API
         sys.path.append(abspath(join(dirname(__file__), self.version)))
 
     def get_application_id(self):
         """
         Get Pinterest application ID and secret from the OS environment.
-        It is best practice not to store credentials in code.
+        It is best practice not to store credentials in code nor to provide
+        credentials on a shell command line.
 
         First, try the version-specific environment variables like
         PINTEREST_V3_APP_ID and PINTEREST_V3_APP_SECRET.
@@ -75,14 +76,10 @@ class ApiConfig:
             self.app_secret = os.environ.get(env_app_secret)
 
         if self.app_id and self.app_secret:
-            print(f"Using application ID and secret from {env_app_id} and {env_app_secret}.")
-        elif self.app_id:
-            print(f"Missing application secret in {env_app_secret}.")
-            exit(1)
-        elif self.app_secret:
-            print(f"Missing application id in {env_app_id}.")
-            exit(1)
-        else:
-            print(f"Missing application id and secret in {env_app_id} and {env_app_secret}.")
-            exit(1)
+            if self.verbosity >= 2:
+                print(f"Using application ID and secret from {env_app_id} and {env_app_secret}.")
+            return
+
+        print(f"{env_app_id} and {env_app_secret} must be set in the environment.")
+        exit(1)
         

--- a/python/src/v3/access_token.py
+++ b/python/src/v3/access_token.py
@@ -1,10 +1,21 @@
 import requests
 
 from access_token_common import AccessTokenCommon
+from user_auth import get_auth_code
 
 class AccessToken(AccessTokenCommon):
     def __init__(self, api_config, name=None):
         super().__init__(api_config, name)
+
+    def oauth(self, scopes=None, refreshable=True):
+        """
+        Execute the OAuth 2.0 process for obtaining an access token.
+        For more information, see IETF RFC 6749: https://tools.ietf.org/html/rfc6749
+        """
+        print('getting auth_code...')
+        auth_code = get_auth_code(self.api_config, scopes=scopes, refreshable=refreshable)
+        print(f'exchanging auth_code for {self.name}...')
+        self.exchange_auth_code(auth_code)
 
     def exchange_auth_code(self, auth_code):
         """

--- a/python/src/v3/access_token.py
+++ b/python/src/v3/access_token.py
@@ -1,0 +1,51 @@
+import requests
+
+from access_token_common import AccessTokenCommon
+
+class AccessToken(AccessTokenCommon):
+    def __init__(self, api_config, name=None):
+        super().__init__(api_config, name)
+
+    def exchange_auth_code(self, auth_code):
+        """
+        Call the Pinterest API to exchange the auth_code (obtained by
+        a redirect from the browser) for the access_token and (if requested)
+        refresh_token.
+        """
+        put_data = {'code': auth_code,
+                    'redirect_uri': self.api_config.redirect_uri,
+                    'grant_type': 'authorization_code'}
+        if (self.api_config.verbosity >= 2):
+            print('PUT', self.api_config.api_uri + '/v3/oauth/access_token/')
+        response = requests.put(self.api_config.api_uri + '/v3/oauth/access_token/',
+                                headers=self.auth_headers, data=put_data)
+        print(response)
+        respdict = response.json()
+        print('status: ' + respdict['status'])
+        if (self.api_config.verbosity >= 3):
+            print('x-pinterest-rid:', response.headers.get('x-pinterest-rid'))
+        """
+        The scope returned in the response includes all of the scopes that
+        have been approved now or in the past by the user.
+        """
+        print('scope: ' + respdict['scope'])
+        self.access_token = respdict['access_token']
+        self.refresh_token = respdict['data'].get('refresh_token')
+        self.scopes = respdict['scope']
+        if self.refresh_token:
+            print('received refresh token')
+
+    def refresh(self):
+        if not self.refresh_token:
+            raise RuntimeError('AccessToken does not have a refresh token')
+        print(f'refreshing {self.name}...')
+        put_data = {'grant_type': 'refresh_token',
+                    'refresh_token': self.refresh_token}
+        if (self.api_config.verbosity >= 2):
+            print('PUT', self.api_config.api_uri + '/v3/oauth/access_token/')
+        response = requests.put(self.api_config.api_uri + '/v3/oauth/access_token/',
+                                headers=self.auth_headers, data=put_data)
+        print(response)
+        if (self.api_config.verbosity >= 3):
+            print('x-pinterest-rid:', response.headers.get('x-pinterest-rid'))
+        self.access_token = response.json()['access_token']

--- a/python/tests/src/v3/test_access_token.py
+++ b/python/tests/src/v3/test_access_token.py
@@ -2,12 +2,12 @@ import unittest
 import mock
 import json
 
-from src.access_token import AccessToken
+from src.v3.access_token import AccessToken
 
 class AccessTokenTest(unittest.TestCase):
 
-    @mock.patch('src.access_token.requests.put')
-    @mock.patch('src.access_token.user_auth.get_auth_code')
+    @mock.patch('src.v3.access_token.requests.put')
+    @mock.patch('src.access_token_common.user_auth.get_auth_code')
     def test_access_token(self, mock_get_auth_code, mock_requests_put):
         mock_get_auth_code.return_value = 'test-auth-code'
 

--- a/python/tests/src/v3/test_access_token.py
+++ b/python/tests/src/v3/test_access_token.py
@@ -7,7 +7,7 @@ from src.v3.access_token import AccessToken
 class AccessTokenTest(unittest.TestCase):
 
     @mock.patch('src.v3.access_token.requests.put')
-    @mock.patch('src.access_token_common.user_auth.get_auth_code')
+    @mock.patch('src.v3.access_token.get_auth_code')
     def test_access_token(self, mock_get_auth_code, mock_requests_put):
         mock_get_auth_code.return_value = 'test-auth-code'
 


### PR DESCRIPTION
Support for version-specific OAuth code in all three current languages: bash, python, and nodejs.

python and nodejs also support different application credentials for different API versions.

